### PR TITLE
Optionally bring your own WorkerPool

### DIFF
--- a/events/listener.go
+++ b/events/listener.go
@@ -3,6 +3,7 @@ package events
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/json"
 
 	"io/ioutil"
 	"net/http"
@@ -83,19 +84,20 @@ func (router *EventRouter) Start(ready chan<- bool) error {
 		return err
 	}
 	eventSuffix := ";handler=" + router.name
-	return router.run(ready, eventSuffix)
+	wp := SkippingWorkerPool(router.workerCount, resourceIDLocker)
+	return router.run(wp, ready, eventSuffix)
 }
 
 func (router *EventRouter) StartWithoutCreate(ready chan<- bool) error {
-	return router.run(ready, "")
+	wp := SkippingWorkerPool(router.workerCount, resourceIDLocker)
+	return router.run(wp, ready, "")
 }
 
-func (router *EventRouter) run(ready chan<- bool, eventSuffix string) (err error) {
-	workers := make(chan *Worker, router.workerCount)
-	for i := 0; i < router.workerCount; i++ {
-		w := newWorker()
-		workers <- w
-	}
+func (router *EventRouter) RunWithWorkerPool(wp WorkerPool) error {
+	return router.run(wp, nil, "")
+}
+
+func (router *EventRouter) run(wp WorkerPool, ready chan<- bool, eventSuffix string) (err error) {
 
 	log.WithFields(log.Fields{
 		"workerCount": router.workerCount,
@@ -129,11 +131,11 @@ func (router *EventRouter) run(ready chan<- bool, eventSuffix string) (err error
 	}
 
 	ph := newPongHandler(router)
+	defer ph.stop()
 	router.eventStream.SetPongHandler(ph.handle)
 	go router.sendWebsocketPings()
 
 	for {
-
 		_, message, err := router.eventStream.ReadMessage()
 		if err != nil {
 			// Error here means the connection is closed. It's normal, so just return.
@@ -145,14 +147,15 @@ func (router *EventRouter) run(ready chan<- bool, eventSuffix string) (err error
 			continue
 		}
 
-		select {
-		case worker := <-workers:
-			go worker.DoWork(message, handlers, router.apiClient, workers)
-		default:
+		event := &Event{}
+		err = json.Unmarshal(message, &event)
+		if err != nil {
 			log.WithFields(log.Fields{
-				"workerCount": router.workerCount,
-			}).Info("No workers available dropping event.")
+				"message": string(message),
+			}).Warnf("Error parsing message: %s", err)
+			continue
 		}
+		wp.HandleWork(event, handlers, router.apiClient)
 	}
 }
 
@@ -169,16 +172,21 @@ func (router *EventRouter) subscribeToEvents(subscribeURL string, accessKey stri
 	ws, resp, err := dialer.Dial(subscribeURL, headers)
 
 	if err != nil {
-		defer resp.Body.Close()
-		body, _ := ioutil.ReadAll(resp.Body)
 		log.WithFields(log.Fields{
-			"status":          resp.Status,
-			"statusCode":      resp.StatusCode,
-			"responseHeaders": resp.Header,
-			"responseBody":    string(body[:]),
-			"error":           err,
-			"subscribeUrl":    subscribeURL,
-		}).Error("Failed to subscribe to events.")
+			"subscribeUrl": subscribeURL,
+		}).Errorf("Error subscribing to events: %s", err)
+		if resp != nil {
+			log.WithFields(log.Fields{
+				"status":          resp.Status,
+				"statusCode":      resp.StatusCode,
+				"responseHeaders": resp.Header,
+			}).Error("Got error response")
+			if resp.Body != nil {
+				defer resp.Body.Close()
+				body, _ := ioutil.ReadAll(resp.Body)
+				log.Errorf("Error response: %s", body)
+			}
+		}
 		return nil, err
 	}
 	return ws, nil

--- a/events/worker.go
+++ b/events/worker.go
@@ -1,40 +1,80 @@
 package events
 
 import (
-	"encoding/json"
-
 	log "github.com/Sirupsen/logrus"
 	"github.com/rancher/event-subscriber/locks"
 	"github.com/rancher/go-rancher/client"
 )
 
-func newWorker() *Worker {
-	return &Worker{}
+type EventLocker func(event *Event) locks.Locker
+
+func nopLocker(_ *Event) locks.Locker { return locks.NopLocker() }
+
+func resourceIDLocker(event *Event) locks.Locker { return locks.KeyLocker(event.ResourceID) }
+
+type WorkerPool interface {
+	HandleWork(event *Event, eventHandlers map[string]EventHandler, apiClient *client.RancherClient)
 }
 
-type Worker struct {
+type skippingWorkerPool struct {
+	workers     chan int
+	eventLocker EventLocker
 }
 
-func (w *Worker) DoWork(rawEvent []byte, eventHandlers map[string]EventHandler, apiClient *client.RancherClient,
-	workers chan *Worker) {
-	defer func() { workers <- w }()
-
-	event := &Event{}
-	err := json.Unmarshal(rawEvent, &event)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"err": err,
-		}).Error("Error unmarshalling event")
-		return
+func SkippingWorkerPool(size int, eventLocker EventLocker) WorkerPool {
+	if eventLocker == nil {
+		eventLocker = nopLocker
 	}
+	wp := &skippingWorkerPool{workers: make(chan int, size), eventLocker: eventLocker}
+	for i := 0; i < size; i++ {
+		wp.workers <- i
+	}
+	return wp
+}
+
+func (wp *skippingWorkerPool) HandleWork(event *Event, eventHandlers map[string]EventHandler, apiClient *client.RancherClient) {
+	select {
+	case w := <-wp.workers:
+		go func() {
+			defer func() { wp.workers <- w }()
+			doWork(event, eventHandlers, apiClient, wp.eventLocker(event))
+		}()
+	default:
+		log.Warnf("No workers available, dropping event. workerCount: %v, event: %v", cap(wp.workers), *event)
+	}
+}
+
+type nonSkippingWorkerPool struct {
+	workers chan int
+}
+
+func NonSkippingWorkerPool(size int) WorkerPool {
+	wp := &nonSkippingWorkerPool{workers: make(chan int, size)}
+	go func() {
+		for i := 0; i < size; i++ {
+			wp.workers <- i
+		}
+	}()
+	return wp
+}
+
+func (wp *nonSkippingWorkerPool) HandleWork(event *Event, eventHandlers map[string]EventHandler, apiClient *client.RancherClient) {
+	w := <-wp.workers
+	go func() {
+		defer func() { wp.workers <- w }()
+		doWork(event, eventHandlers, apiClient, nopLocker(event))
+	}()
+}
+
+func doWork(event *Event, eventHandlers map[string]EventHandler, apiClient *client.RancherClient, locker locks.Locker) {
 
 	if event.Name != "ping" {
 		log.WithFields(log.Fields{
-			"event": string(rawEvent[:]),
+			"event": *event,
 		}).Debug("Processing event.")
 	}
 
-	unlocker := locks.Lock(event.ResourceID)
+	unlocker := locker.Lock()
 	if unlocker == nil {
 		log.WithFields(log.Fields{
 			"resourceId": event.ResourceID,
@@ -44,8 +84,7 @@ func (w *Worker) DoWork(rawEvent []byte, eventHandlers map[string]EventHandler, 
 	defer unlocker.Unlock()
 
 	if fn, ok := eventHandlers[event.Name]; ok {
-		err = fn(event, apiClient)
-		if err != nil {
+		if err := fn(event, apiClient); err != nil {
 			log.WithFields(log.Fields{
 				"eventName":  event.Name,
 				"eventId":    event.ID,

--- a/locks/locks.go
+++ b/locks/locks.go
@@ -1,10 +1,13 @@
 package locks
 
-var lockRequests chan *lockRequest
+var lockRequests = make(chan *lockRequest)
 
 func init() {
-	lockRequests = make(chan *lockRequest)
 	go locker()
+}
+
+type Locker interface {
+	Lock() Unlocker
 }
 
 // Unlocker Interface for unlocking a key that was provided to Lock()
@@ -12,13 +15,45 @@ type Unlocker interface {
 	Unlock()
 }
 
-// Lock Provides an application-wide lock on the provided key.
-// If the lock is obtained, it will return an Unlocker.
+type nopLocker struct{}
+
+var theNopLocker = &nopLocker{}
+
+// NopLocker returns a Locker which always works but does nothing: it's used to effectively skip locking.
+func NopLocker() Locker {
+	return theNopLocker
+}
+
+// Lock method of *nopLocker always succeeds but does not actually do anything.
+func (nl *nopLocker) Lock() Unlocker {
+	return nl
+}
+
+// Unlock method of *nopLocker does not actually do anything. It is here to satisfy the interface.
+func (nl *nopLocker) Unlock() {
+	return
+}
+
+type keyLocker struct {
+	key interface{}
+}
+
+// KeyLocker provides an application-wide locker on the specified key.
+func KeyLocker(key interface{}) Locker {
+	return &keyLocker{key: key}
+}
+
+// Lock method works like this: if the lock is obtained, it will return an Unlocker.
 // If the lock is not successfully obtained, nil will be returned.
-func Lock(key string) Unlocker {
-	lockRequest := newLockRequest(key, LOCK)
+func (kl *keyLocker) Lock() Unlocker {
+	lockRequest := newLockRequest(kl.key, LOCK)
 	lockRequests <- lockRequest
 	return <-lockRequest.response
+}
+
+// Lock function provides a backwards compatible API for application-wide locking on a key
+func Lock(key interface{}) Unlocker {
+	return KeyLocker(key).Lock()
 }
 
 type operation int
@@ -29,12 +64,12 @@ const (
 )
 
 type lockRequest struct {
-	key      string
+	key      interface{}
 	op       operation
 	response chan Unlocker
 }
 
-func newLockRequest(key string, op operation) *lockRequest {
+func newLockRequest(key interface{}, op operation) *lockRequest {
 	return &lockRequest{
 		key:      key,
 		op:       op,
@@ -43,22 +78,21 @@ func newLockRequest(key string, op operation) *lockRequest {
 }
 
 type unlockerImpl struct {
-	key string
+	key interface{}
 }
 
 func (u *unlockerImpl) Unlock() {
 	lockRequests <- newLockRequest(u.key, UNLOCK)
 }
 
-func newUnlocker(key string) *unlockerImpl {
+func newUnlocker(key interface{}) *unlockerImpl {
 	return &unlockerImpl{key: key}
 }
 
 func locker() {
 	// note: bool value is meaningless. This is a set
-	lockedItems := make(map[string]bool)
-	for {
-		lockReq := <-lockRequests
+	lockedItems := make(map[interface{}]bool)
+	for lockReq := range lockRequests {
 		switch lockReq.op {
 		case LOCK:
 			if _, locked := lockedItems[lockReq.key]; locked {

--- a/locks/locks_test.go
+++ b/locks/locks_test.go
@@ -7,18 +7,18 @@ import (
 
 func TestLock(t *testing.T) {
 
-	unlocker := Lock("foo1")
+	unlocker := KeyLocker("foo1").Lock()
 	if unlocker == nil {
 		t.Errorf("Didn't obtain lock")
 	}
 
-	unlocker2 := Lock("foo1")
+	unlocker2 := KeyLocker("foo1").Lock()
 	if unlocker2 != nil {
 		t.Error("Did obtain lock")
 	}
 
 	unlocker.Unlock()
-	unlocker = Lock("foo1")
+	unlocker = KeyLocker("foo1").Lock()
 	if unlocker == nil {
 		t.Errorf("Didn't obtain lock")
 	}


### PR DESCRIPTION
Optionally bring your own WorkerPool (and event processing locker - as part of it)

Also:
- stop pongHandler when stopping the event router
- don't panic on unexpected connection loss
