### PR TITLE
close events stream in case of failure

### DIFF
--- a/events/listener.go
+++ b/events/listener.go
@@ -187,6 +187,7 @@ func (router *EventRouter) subscribeToEvents(subscribeURL string, accessKey stri
 				log.Errorf("Error response: %s", body)
 			}
 		}
+		ws.Close()
 		return nil, err
 	}
 	return ws, nil


### PR DESCRIPTION
To address https://github.com/rancher/rancher/issues/7849

Upon getting lots of 401 errors, the memory use grow might be related. @cjellick need your opinion