### PR TITLE
Set HandshakeTimeout on websocket connection

### DIFF
--- a/events/listener.go
+++ b/events/listener.go
@@ -165,7 +165,9 @@ func (router *EventRouter) Stop() {
 }
 
 func (router *EventRouter) subscribeToEvents(subscribeURL string, accessKey string, secretKey string, data url.Values) (*websocket.Conn, error) {
-	dialer := &websocket.Dialer{}
+	dialer := &websocket.Dialer{
+		HandshakeTimeout: time.Second * 30,
+	}
 	headers := http.Header{}
 	headers.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(accessKey+":"+secretKey)))
 	subscribeURL = subscribeURL + "?" + data.Encode()


### PR DESCRIPTION
We've observed users' metadata containers getting hung up while
initializing. A thread dump indicated that the initialization was stuck
while attempting to establish the tpc connection.

Here's the offending goroutine:
```
goroutine 30 [IO wait, 1371 minutes]:
net.runtime_pollWait(0x7f4db02bc9a0, 0x72, 0x1f)
    /usr/local/go/src/runtime/netpoll.go:160 +0x59
net.(*pollDesc).wait(0xc42006db10, 0x72, 0xc420682fa0, 0xc4200740b0)
    /usr/local/go/src/net/fd_poll_runtime.go:73 +0x38
net.(*pollDesc).waitRead(0xc42006db10, 0xff8c20, 0xc4200740b0)
    /usr/local/go/src/net/fd_poll_runtime.go:78 +0x34
net.(*netFD).Read(0xc42006dab0, 0xc4204d1800, 0x400, 0x400, 0x0, 0xff8c20, 0xc4200740b0)
    /usr/local/go/src/net/fd_unix.go:243 +0x1a1
net.(*conn).Read(0xc4204b60e0, 0xc4204d1800, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/net.go:173 +0x70
crypto/tls.(*block).readFromUntil(0xc42023dcb0, 0x7f4db0b8a0c8, 0xc4204b60e0, 0x5, 0xc4204b60e0, 0xc42012c340)
    /usr/local/go/src/crypto/tls/conn.go:472 +0x91
crypto/tls.(*Conn).readRecord(0xc420396e00, 0x416, 0xa3, 0x0)
    /usr/local/go/src/crypto/tls/conn.go:574 +0xc4
crypto/tls.(*Conn).readHandshake(0xc420396e00, 0xc420748816, 0xc4207488c0, 0x9e, 0x9e)
    /usr/local/go/src/crypto/tls/conn.go:925 +0x8f
crypto/tls.(*Conn).clientHandshake(0xc420396e00, 0xb5fa90, 0xc420396f00)
    /usr/local/go/src/crypto/tls/handshake_client.go:159 +0x99f
crypto/tls.(*Conn).Handshake(0xc420396e00, 0x0, 0x0)
    /usr/local/go/src/crypto/tls/conn.go:1232 +0xd3
github.com/rancher/rancher-metadata/vendor/github.com/gorilla/websocket.(*Dialer).Dial(0xc42035aa50, 0xc420146840, 0x52, 0xc42023db00, 0x0, 0x0, 0x0, 0x0)
    /go/src/github.com/rancher/rancher-metadata/vendor/github.com/gorilla/websocket/client.go:307 +0x1381
github.com/rancher/rancher-metadata/vendor/github.com/rancher/event-subscriber/events.(*EventRouter).subscribeToEvents(0xc4203b1ae0, 0xc420146840, 0x52, 0xc420012012, 0x14, 0xc420010092, 0x28, 0xc42023dad0, 0x0, 0x0, ...)
    /go/src/github.com/rancher/rancher-metadata/vendor/github.com/rancher/event-subscriber/events/listener.go:172 +0x299
github.com/rancher/rancher-metadata/vendor/github.com/rancher/event-subscriber/events.(*EventRouter).run(0xc4203b1ae0, 0xff68e0, 0xc420432710, 0x0, 0x0, 0x0, 0x0, 0x0)
    /go/src/github.com/rancher/rancher-metadata/vendor/github.com/rancher/event-subscriber/events/listener.go:121 +0x555
github.com/rancher/rancher-metadata/vendor/github.com/rancher/event-subscriber/events.(*EventRouter).RunWithWorkerPool(0xc4203b1ae0, 0xff68e0, 0xc420432710, 0x1, 0x1)
    /go/src/github.com/rancher/rancher-metadata/vendor/github.com/rancher/event-subscriber/events/listener.go:97 +0x5a
main.(*Subscriber).Subscribe.func1(0xc4200705a0, 0xc4203b1ae0)
    /go/src/github.com/rancher/rancher-metadata/subscribe.go:88 +0x87
created by main.(*Subscriber).Subscribe
    /go/src/github.com/rancher/rancher-metadata/subscribe.go:93 +0x2a0
```